### PR TITLE
Add OpenAI base URL settings and Bedrock support

### DIFF
--- a/docs/AI-Search.md
+++ b/docs/AI-Search.md
@@ -129,6 +129,13 @@ SWIRL, via LiteLLM and direct connections, supports major GAI/LLMs, including:
 
 For assistance with any of these or additional models, please [contact support](#support).
 
+To use an **OpenAI-compatible endpoint** such as **AWS Bedrock**, set the following in your `.env` file:
+
+```ini
+OPENAI_API_BASE='https://bedrock-runtime.us-east-1.amazonaws.com/openai'
+OPENAI_API_VERSION='2023-05-15'
+```
+
 **External Model Resources**
 
 - [Full list of Supported Embeddings](https://docs.litellm.ai/docs/embedding/supported_embedding)

--- a/docs/RAG-Guide.md
+++ b/docs/RAG-Guide.md
@@ -39,6 +39,13 @@ SWIRL supports Real-Time **Retrieval Augmented Generation (RAG)** out of the box
     AZURE_MODEL=<your-azure-openai-model>
     ```
 
+    Optionally specify a compatible endpoint (e.g., AWS Bedrock):
+
+    ```shell
+    OPENAI_API_BASE='https://bedrock-runtime.us-east-1.amazonaws.com/openai'
+    OPENAI_API_VERSION='2023-05-15'
+    ```
+
     {: .warning }  
     **SWIRL AI Search Community Edition supports RAG only with OpenAI and Azure OpenAI.**  
     The [Enterprise Edition](AI-Search#connecting-to-generative-ai-gai-and-large-language-models-llms) supports additional providers.  

--- a/swirl/openai/openai.py
+++ b/swirl/openai/openai.py
@@ -56,10 +56,17 @@ class OpenAIClient:
         try:
             if provider == "OPENAI":
                 from openai import OpenAI
-                ai_client = OpenAI(api_key=key)
+                api_base = getattr(settings, 'OPENAI_API_BASE', '')
+                api_version = getattr(settings, 'OPENAI_API_VERSION', '')
+                ai_client = OpenAI(api_key=key, base_url=api_base or None, api_version=api_version or None)
             elif provider == "AZUREAI":
                 from openai import AzureOpenAI
                 ai_client = AzureOpenAI(api_key=key, azure_endpoint=self._azure_endpoint, api_version="2023-10-01-preview")
+            elif provider == "BEDROCKAI":
+                from openai import OpenAI
+                api_base = getattr(settings, 'OPENAI_API_BASE', '')
+                api_version = getattr(settings, 'OPENAI_API_VERSION', '')
+                ai_client = OpenAI(api_key=key, base_url=api_base or None, api_version=api_version or None)
             else:
                 raise NotImplementedError(f"Unknown AI provider {provider}. Client initialization not supported.")
         except Exception as err:

--- a/swirl/tests/test_openai_client.py
+++ b/swirl/tests/test_openai_client.py
@@ -1,0 +1,27 @@
+import pytest
+from unittest import mock
+from django.test import override_settings
+from swirl.openai.openai import OpenAIClient, AI_QUERY_USE
+
+
+@pytest.mark.django_db
+def test_openai_client_custom_base_url():
+    with override_settings(
+        OPENAI_API_KEY='test-key',
+        OPENAI_API_BASE='http://bedrock.aws',
+        OPENAI_API_VERSION='2023-05-15',
+        AZURE_OPENAI_KEY='',
+        AZURE_MODEL='',
+        AZURE_OPENAI_ENDPOINT='',
+    ):
+        with mock.patch('openai.OpenAI') as mock_openai:
+            instance = mock.MagicMock()
+            mock_openai.return_value = instance
+            client = OpenAIClient(AI_QUERY_USE)
+            mock_openai.assert_called_once_with(
+                api_key='test-key',
+                base_url='http://bedrock.aws',
+                api_version='2023-05-15'
+            )
+            assert client.openai_client == instance
+

--- a/swirl_server/settings.py
+++ b/swirl_server/settings.py
@@ -295,6 +295,8 @@ OPENAI_API_KEY = env.get_value('OPENAI_API_KEY', default='')
 AZURE_OPENAI_KEY = env.get_value('AZURE_OPENAI_KEY', default='')
 AZURE_OPENAI_ENDPOINT = env.get_value('AZURE_OPENAI_ENDPOINT', default='')
 AZURE_MODEL = env.get_value('AZURE_MODEL', default='')
+OPENAI_API_BASE = env.get_value('OPENAI_API_BASE', default='')
+OPENAI_API_VERSION = env.get_value('OPENAI_API_VERSION', default='')
 
 # Defines for RAG ChatGPT models
 CGPT_MODEL_3 = "gpt-3.5-turbo"


### PR DESCRIPTION
## Summary
- add `OPENAI_API_BASE` and `OPENAI_API_VERSION` settings
- allow custom base URL when creating the OpenAI client and add a `BEDROCKAI` provider type
- document these environment variables with an AWS Bedrock example
- test that `OpenAIClient` uses the configured base URL

## Testing
- `pytest swirl/tests/test_openai_client.py::test_openai_client_custom_base_url -q` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install -r requirements.txt -r requirements-test.txt` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687c6d339ce4832fbd739496167c2a5f